### PR TITLE
Renombrar Control a Control y Seguimiento

### DIFF
--- a/frontend/src/views/dashboard/components/Maquinaria/components/MaquinariaDetalle.js
+++ b/frontend/src/views/dashboard/components/Maquinaria/components/MaquinariaDetalle.js
@@ -14,6 +14,8 @@ import BlockIcon from '@mui/icons-material/Block';
 import EditIcon from '@mui/icons-material/Edit';
 
 
+const LABEL_OVERRIDES = { Control: 'Control y Seguimiento' };
+
 const maquinariaImage = 'https://images.unsplash.com/photo-1511918984145-48de785d4c4e?auto=format&fit=crop&w=400&q=80';
 
 const MaquinariaDetalle = ({
@@ -210,7 +212,7 @@ const MaquinariaDetalle = ({
               onClick={() => setActiveSection(sec)}
               sx={{ minWidth: 120, justifyContent: 'flex-start', py: 1 }}
             >
-              {sec}
+              {LABEL_OVERRIDES[sec] || sec}
             </Button>
           ))}
         </Box>

--- a/frontend/src/views/dashboard/components/Reportes/ReportesDashboard.js
+++ b/frontend/src/views/dashboard/components/Reportes/ReportesDashboard.js
@@ -68,7 +68,7 @@ const ReportesDashboard = ({
 
     // Análisis de datos
     const secciones = [
-      { key: 'control', label: 'Control', data: control },
+      { key: 'control', label: 'Control y Seguimiento', data: control },
       { key: 'asignacion', label: 'Asignación', data: asignacion },
       { key: 'mantenimiento', label: 'Mantenimiento', data: mantenimiento },
       { key: 'soat', label: 'SOAT', data: soat },

--- a/frontend/src/views/dashboard/components/Reportes/ReportesMain.js
+++ b/frontend/src/views/dashboard/components/Reportes/ReportesMain.js
@@ -218,7 +218,7 @@ const ReportesMain = () => {
                 fields={maquinariaFields}
                 emptyMessage="No hay datos de maquinaria"
               />
-              <TablaGenerica title="Control" data={control} ocultarCampos={ocultarCampos} reemplazos={{ 'gerente': 'Gerente', 'encargado': 'Encargado', 'estado': 'Estado', 'ubicacion': 'Ubicación' }} />
+              <TablaGenerica title="Control y Seguimiento" data={control} ocultarCampos={ocultarCampos} reemplazos={{ 'gerente': 'Gerente', 'encargado': 'Encargado', 'estado': 'Estado', 'ubicacion': 'Ubicación' }} />
               <TablaGenerica title="Asignación" data={asignacion} ocultarCampos={ocultarCampos} reemplazos={{ 'fecha_asignacion': 'Fecha de Asignación', 'recorrido_km': 'Recorrido Km', 'encargado': 'Encargado', 'ubicacion': 'Ubicación' }} />
               <TablaGenerica title="Mantenimiento" data={mantenimiento} ocultarCampos={ocultarCampos} />
               <TablaGenerica title="SOAT" data={soat} ocultarCampos={ocultarCampos} />

--- a/frontend/src/views/dashboard/components/Reportes/exportacionExcel.js
+++ b/frontend/src/views/dashboard/components/Reportes/exportacionExcel.js
@@ -105,7 +105,7 @@ function exportXLS(data, filename = 'reporte') {
 
   // Otras tablas
   const tablas = [
-    { key: 'control', label: 'Control' },
+    { key: 'control', label: 'Control y Seguimiento' },
     { key: 'asignacion', label: 'Asignación' },
     { key: 'mantenimiento', label: 'Mantenimiento' },
     { key: 'soat', label: 'SOAT' },

--- a/frontend/src/views/dashboard/components/Reportes/exportacionPDF.js
+++ b/frontend/src/views/dashboard/components/Reportes/exportacionPDF.js
@@ -198,7 +198,7 @@ function exportPDF({ maquinaria, depreciaciones, pronosticos, control, asignacio
     doc.setTextColor(33, 33, 33);
     let intro = '';
     switch (title) {
-      case 'Control':
+      case 'Control y Seguimiento':
         intro = 'Esta sección muestra los controles realizados sobre la maquinaria.';
         break;
       case 'Asignación':
@@ -299,7 +299,7 @@ function exportPDF({ maquinaria, depreciaciones, pronosticos, control, asignacio
   }
   
   // Renderizar todas las secciones
-  renderSection('Control', control);
+  renderSection('Control y Seguimiento', control);
   renderSection('Asignación', asignacion);
   renderSection('Mantenimiento', mantenimiento);
   renderSection('SOAT', soat);
@@ -656,7 +656,7 @@ function exportPDFMasivo(data, filename = 'reporte') {
 
   // Otras tablas
   const tablas = [
-    { key: 'control', label: 'Control' },
+    { key: 'control', label: 'Control y Seguimiento' },
     { key: 'asignacion', label: 'Asignación' },
     { key: 'mantenimiento', label: 'Mantenimiento' },
     { key: 'soat', label: 'SOAT' },

--- a/frontend/src/views/user-profile/UserManagement.js
+++ b/frontend/src/views/user-profile/UserManagement.js
@@ -13,7 +13,7 @@ import PersonAddIcon from '@mui/icons-material/PersonAdd';
 const cargos = ["Encargado", "Técnico"];
 const MODULOS = [
   'Maquinaria',
-  'Control',
+  'Control y Seguimiento',
   'Asignación',
   'Mantenimiento',
   'SOAT',


### PR DESCRIPTION
Update display text 'Control' to 'Control y Seguimiento' across the frontend UI to match user's request without affecting underlying logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fb2b980-0bc3-4709-90d4-e9c5c3f25341">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fb2b980-0bc3-4709-90d4-e9c5c3f25341">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

